### PR TITLE
Documentation: correct databag structure and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ You can use this cookbook in two ways:
 
 Both methods require you to define a [databag](#databag) to define SSH key pairs. Defining attributes is not required if you only want to use the LWRP.
 
+Note that the user whose keys you wish to populate must already exist,
+and *also* have a databag entry.  That is, if you have:
+
+```ruby
+user_ssh_keys_key 'root' do
+  authorized_users %w(bob)
+  data_bag 'keys'
+  action :create
+end
+```
+
+then you must have a databag entry for both "bob" *and* "root".
+
 ### user-ssh-keys::default
 
 Include `user-ssh-keys` in your node's `run_list`:

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ This resource will add authorized keys from the provided list (`authorized_keys`
 
 ## Databag
 
-The databag is an `Hash` with usernames as keys. Each user can have a list of keypairs (as an `Array`).
-A keypais is described as follow:
+The databag is a `Hash` with usernames as keys. Each user can have a list of keypairs (as an `Array`).
+A keypair is described as follow:
 
 | Key    | Type   | Default | Description                |
 | :------|:------ | :------ | :------------------------- |
@@ -55,7 +55,7 @@ A keypais is described as follow:
 
 ## Usage
 
-You can use this cookbook in tow ways:
+You can use this cookbook in two ways:
 
 * using the [default](#user-ssh-keys-default) recipe and providing (attributes)[#attributes]
 * using the [LWRP](#lwrp) 

--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ Include `user-ssh-keys` in your node's `run_list`:
 #### Example databag
 
 ```json
-{    
-    "bob": [
+{
+    "id": "bob",
+    "keys": [
         {
             "id": "my_key",
             "pub": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDmz4D...",


### PR DESCRIPTION
Hi there -- this PR corrects a few things in the documentation:

- a couple of minor typos
- the user whose key is being managed needs to have a databag entry; otherwise, the cookbook throws an error
- the example databag structure is incorrect:  the SSH keys need to be in a separate array called "keys".