### PR TITLE
Fix ConfigurationError msg when user doesn't exist

### DIFF
--- a/libraries/user.rb
+++ b/libraries/user.rb
@@ -9,7 +9,7 @@ module PMSIpilot
 
           true
         rescue
-          raise Chef::Exceptions::ConfigurationError, "User #{user} does not exist"
+          raise Chef::Exceptions::ConfigurationError, "User #{username} does not exist"
         end
       end
 


### PR DESCRIPTION
This will fix this error message:
```
================================================================================
Error executing action `create` on resource 'user_ssh_keys_key[myuser]'
================================================================================
ChefConfig::ConfigurationError
------------------------------
User {:authorized_keys=>["ssh-rsa AAAA....", "ssh-rsa AAAA...."], :authorized_users=>[]} does not exist
```